### PR TITLE
Restore Nature Scope and production services

### DIFF
--- a/.github/workflows/deploy-oracle.yml
+++ b/.github/workflows/deploy-oracle.yml
@@ -1,4 +1,4 @@
-name: deploy-slicer
+name: deploy-oracle
 
 on:
   workflow_dispatch:
@@ -33,16 +33,24 @@ jobs:
 
       - name: Deploy
         env:
-          SSH_KEY: ${{ secrets.SLICER_SSH_KEY }}
+          SSH_KEY: ${{ secrets.ORACLE_SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "${SSH_KEY}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key cougar@slicer << 'EOF'
-            cd /srv/infra/livia
-            git pull origin main
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key ubuntu@oracle << 'EOF'
+            cd /home/ubuntu/livia-oracle
+            git pull --ff-only origin main
             sudo systemctl restart livia
-            sleep 10
-            systemctl is-active livia && echo "Deploy successful"
+            for attempt in $(seq 1 60); do
+              if curl --fail --silent http://127.0.0.1:2259/health > /dev/null; then
+                echo "Deploy successful"
+                exit 0
+              fi
+              sleep 1
+            done
+            echo "Deploy failed health check"
+            journalctl -u livia -n 100 --no-pager
+            exit 1
           EOF

--- a/src/main/java/xyz/arryan/livia/config/RequestLoggingInstrumentation.java
+++ b/src/main/java/xyz/arryan/livia/config/RequestLoggingInstrumentation.java
@@ -23,7 +23,10 @@ public class RequestLoggingInstrumentation extends SimplePerformantInstrumentati
             InstrumentationState state) {
 
         long startTime = System.currentTimeMillis();
-        String query = parameters.getQuery().replaceAll("\\s+", " ").trim();
+        String query = parameters.getQuery()
+                .replaceAll("\"(?:\\\\.|[^\"\\\\])*\"", "\"[REDACTED]\"")
+                .replaceAll("\\s+", " ")
+                .trim();
 
         String clientIp = "unknown";
         String region = System.getenv("LIVIA_REGION");

--- a/src/main/java/xyz/arryan/livia/datafetchers/ApiKeyDataFetcher.java
+++ b/src/main/java/xyz/arryan/livia/datafetchers/ApiKeyDataFetcher.java
@@ -80,7 +80,7 @@ public class ApiKeyDataFetcher {
 
             String requestBody = """
                 {
-                    "models": ["gpt-4o"],
+                    "models": ["gpt-5-nano", "gpt-4o"],
                     "max_budget": 0.40,
                     "duration": "24h",
                     "metadata": {

--- a/src/main/java/xyz/arryan/livia/datafetchers/EventsDataFetcher.java
+++ b/src/main/java/xyz/arryan/livia/datafetchers/EventsDataFetcher.java
@@ -91,9 +91,9 @@ public class EventsDataFetcher {
         logger.info(lp("input valid: start={} within [{}..{}]"), formattedDate, minDate, maxDate);
 
         // ===== C. API request build =====
-        // end date = now + 5 years (original logic preserved)
-        final LocalDate dynamicEndDate = LocalDate.now(mountainTime).plusYears(5);
-        final String formattedEndDate = dynamicEndDate.format(formatter);
+        // EONET's end date is inclusive. Keep the request bounded to today so the
+        // response contains only the requested historical window.
+        final String formattedEndDate = maxDate.format(formatter);
 
         final String api_source = "https://eonet.gsfc.nasa.gov/api/v3/events?start="
                 + formattedDate + "&end=" + formattedEndDate + "&status=all";
@@ -208,8 +208,7 @@ public class EventsDataFetcher {
                             magnitudeValue = number.floatValue();
                         }
 
-                        @SuppressWarnings("unchecked")
-                        List<Double> coords = (List<Double>) geoMap.get("coordinates");
+                        List<Double> coords = normalizeCoordinates(geoMap.get("coordinates"));
 
                         Geometry geometry = Geometry.newBuilder()
                                 // keep existing behavior: Double in builder from Float source
@@ -243,6 +242,34 @@ public class EventsDataFetcher {
 
         // ===== G. Return =====
         return finalEvents;
+    }
+
+    /**
+     * Nature Scope renders every geometry as a map marker, while EONET can return
+     * Point, Polygon, and MultiPolygon coordinate shapes. GraphQL exposes the
+     * marker location as a single [longitude, latitude] pair, so recursively find
+     * the first valid pair for nested shapes instead of passing nested arrays to
+     * the Float serializer.
+     */
+    static List<Double> normalizeCoordinates(Object rawCoordinates) {
+        if (!(rawCoordinates instanceof List<?> coordinates) || coordinates.isEmpty()) {
+            return List.of();
+        }
+
+        if (coordinates.size() >= 2
+                && coordinates.get(0) instanceof Number longitude
+                && coordinates.get(1) instanceof Number latitude) {
+            return List.of(longitude.doubleValue(), latitude.doubleValue());
+        }
+
+        for (Object nestedCoordinates : coordinates) {
+            List<Double> normalized = normalizeCoordinates(nestedCoordinates);
+            if (normalized.size() == 2) {
+                return normalized;
+            }
+        }
+
+        return List.of();
     }
 
 }

--- a/src/main/java/xyz/arryan/livia/datafetchers/PictureDataFetcher.java
+++ b/src/main/java/xyz/arryan/livia/datafetchers/PictureDataFetcher.java
@@ -83,7 +83,11 @@ public class PictureDataFetcher {
         logger.info(lp("MongoDB cache miss: no picture for {}; will fetch and generate"), date);
 
         // Step 2: Fetch from Ellanan APOD API
-        final String api_source = "https://apod.ellanan.com/api/?date=" + date;
+        final String nasaApiKey = System.getenv("NASA_API_KEY") != null
+                ? System.getenv("NASA_API_KEY")
+                : "DEMO_KEY";
+        final String api_source = "https://api.nasa.gov/planetary/apod?api_key="
+                + nasaApiKey + "&date=" + date;
         final String response = fetchWithRetry(api_source, 2);
         if (response == null) {
             throw new GraphQLException("Failed to fetch picture for " + date + " after multiple attempts. Please try again later.");

--- a/src/test/java/xyz/arryan/livia/datafetchers/EventsDataFetcherTest.java
+++ b/src/test/java/xyz/arryan/livia/datafetchers/EventsDataFetcherTest.java
@@ -1,0 +1,58 @@
+package xyz.arryan.livia.datafetchers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EventsDataFetcherTest {
+
+    @Test
+    void preservesPointCoordinates() {
+        assertEquals(
+                List.of(-122.42, 37.77),
+                EventsDataFetcher.normalizeCoordinates(List.of(-122.42, 37.77))
+        );
+    }
+
+    @Test
+    void extractsMarkerFromPolygonCoordinates() {
+        List<?> polygon = List.of(
+                List.of(
+                        List.of(-120.0, 35.0),
+                        List.of(-121.0, 36.0),
+                        List.of(-120.0, 35.0)
+                )
+        );
+
+        assertEquals(
+                List.of(-120.0, 35.0),
+                EventsDataFetcher.normalizeCoordinates(polygon)
+        );
+    }
+
+    @Test
+    void extractsMarkerFromMultiPolygonCoordinates() {
+        List<?> multiPolygon = List.of(
+                List.of(
+                        List.of(
+                                List.of(140.0, -30.0),
+                                List.of(141.0, -31.0),
+                                List.of(140.0, -30.0)
+                        )
+                )
+        );
+
+        assertEquals(
+                List.of(140.0, -30.0),
+                EventsDataFetcher.normalizeCoordinates(multiPolygon)
+        );
+    }
+
+    @Test
+    void rejectsMalformedCoordinates() {
+        assertEquals(List.of(), EventsDataFetcher.normalizeCoordinates(List.of("unknown")));
+        assertEquals(List.of(), EventsDataFetcher.normalizeCoordinates(null));
+    }
+}


### PR DESCRIPTION
## What changed

- Normalize EONET Point, Polygon, and MultiPolygon coordinates into map-marker pairs for Nature Scope.
- Bound EONET requests to the current date.
- Add regression tests for nested coordinate shapes.
- Redact GraphQL string literals from request logs.
- Preserve the Oracle production changes for NASA APOD and GPT-5 Nano support.
- Replace the stale Slicer deployment target with the actual Oracle host, repository path, and health check.

## Why

Nature Scope failed whenever EONET returned nested polygon coordinates because GraphQL attempted to serialize an array as a Float. Production also had server-only changes and a deployment workflow pointing at the wrong machine.

## Validation

- `./gradlew test --no-daemon` on Oracle Java 21: passed.
- Live production Events query: 405 events, zero GraphQL errors, zero invalid coordinate pairs.
- Live health and GraphQL server query: HTTP 200.
- Sensitive `apiKey` argument confirmed redacted in production logs.
